### PR TITLE
Add graceful exit support to `listen_mo_messages` command

### DIFF
--- a/src/smpp_gateway/utils.py
+++ b/src/smpp_gateway/utils.py
@@ -1,5 +1,7 @@
 import base64
 import itertools
+import logging
+import signal
 import string
 
 from typing import Any, Dict
@@ -7,6 +9,34 @@ from typing import Any, Dict
 import smpplib
 
 ASCII_PRINTABLE_BYTES = {ord(c) for c in string.printable}
+
+logger = logging.getLogger(__name__)
+
+
+def set_exit_signals(signals=[signal.SIGINT, signal.SIGTERM]):
+    """
+    Helper method for handling graceful exit signals such as SIGINT and SIGTERM.
+
+    Use like so:
+
+    exit_signal_received = set_exit_signals()
+    while True:
+        get_and_process_some_data()
+        if exit_signal_received():
+            logger.info("Received exit signal, leaving loop...")
+            return
+    """
+    _received_exit_signal = False
+
+    def set_received_exit_signal(sig_num, stack_frame):
+        nonlocal _received_exit_signal
+        logger.info(f"Got signal {sig_num}, setting exit_signal_received = True")
+        _received_exit_signal = True
+
+    for sig in signals:
+        signal.signal(sig, set_received_exit_signal)
+
+    return lambda: _received_exit_signal
 
 
 def grouper(iterable, n):


### PR DESCRIPTION
Still works for `smpp_client`:
```
$ python manage.py smpp_client foo
2022-12-19 23:06:46,412 smpp_gateway.queries INFO     Waiting for notifications on channel 'foo'
2022-12-19 23:06:46,413 smpp.Client.140545233456720 INFO     Connecting to 1.2.3.4:2775...
2022-12-19 23:06:46,416 smpp.Client.140545233456720 INFO     Entering main listen loop
^C2022-12-19 23:06:53,511 smpp_gateway.utils   INFO     Got signal 2, setting exit_signal_received = True

2022-12-19 23:06:56,433 smpp.Client.140545233456720 INFO     Got exit signal, leaving listen loop
2022-12-19 23:06:56,433 smpp.Client.140545233456720 INFO     Unbinding...
2022-12-19 23:06:56,435 smpp.Client.140545233456720 INFO     Disconnecting...
```

Also works for `listen_mo_messages`:
```
$ python manage.py listen_mo_messages
2022-12-19 23:07:04,345 smpp_gateway.queries INFO     Waiting for notifications on channel 'new_mo_msg'
^C2022-12-19 23:07:07,244 smpp_gateway.utils   INFO     Got signal 2, setting exit_signal_received = True
2022-12-19 23:07:09,347 smpp_gateway.subscribers INFO     Received exit signal, leaving listen loop...
```