### PR TITLE
Avoid IntegrityError when short_message is None

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.11.5
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ docker run \
     -e POSTGRES_DB=test_database \
     -e POSTGRES_USER=test_user \
     -e POSTGRES_PASSWORD=test_password \
-    postgres:10.18
+    postgres:15
 # wait for DB to start up
 
 pytest

--- a/src/smpp_gateway/client.py
+++ b/src/smpp_gateway/client.py
@@ -123,7 +123,7 @@ class PgSmppClient(smpplib.client.Client):
             create_time=now,
             modify_time=now,
             backend=self.backend,
-            short_message=pdu.short_message,
+            short_message=pdu.short_message or b"",
             params=params,
             status=MOMessage.Status.NEW,
         )


### PR DESCRIPTION
Fix for:

```
null value in column "short_message" of relation "smpp_gateway_momessage" violates not-null constraint
```

Rather than allowing nulls, convert this to `b""` which seems more consistent with the [SMPP spec](https://smpp.org/SMPP_v3_4_Issue1_2.pdf) (this is a required parameter, but length of zero is allowed).