### PR TITLE
Add support for Python 3.12.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     services:
       postgres:

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Framework :: Django",
             "Framework :: Django :: 3.2",
             "Framework :: Django :: 4.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = {py38,py39,py310}-dj32,
-          {py38,py39,py310,py311}-dj42
+          {py38,py39,py310,py311,py312}-dj42
 
 # Configuration for https://github.com/ymyzk/tox-gh-actions
 [gh-actions]
@@ -9,6 +9,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [default]
 deps = -r{toxinidir}/test-requirements.txt
@@ -19,6 +20,7 @@ basepython =
      py39: python3.9
      py310: python3.10
      py311: python3.11
+     py312: python3.12
 deps =
     dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<5.0


### PR DESCRIPTION
This PR updates the tox config and the GitHub Actions workflow to test against Python 3.12, and adds Python 3.12 to the list of supported Python versions in setup.py

Tox summary:
![smpp_tox](https://github.com/user-attachments/assets/df978cf6-3f7b-4097-a8c3-687801f848ea)
